### PR TITLE
Use the Pro client API for security status information

### DIFF
--- a/monitoring/security/securitystatus.py
+++ b/monitoring/security/securitystatus.py
@@ -11,19 +11,23 @@ try:
     from uaclient.api.u.pro.packages.updates.v1 import updates
     from uaclient.api.u.pro.status.enabled_services.v1 import enabled_services
 
+    # Some of these calls to the pro api can take time and we have a 10 second limit on Landscape scripts
+    # so we will call the endpoints once and reuse the results
+    update_information_summary = updates().summary
+    enabled_pro_services_list = list(i.name for i in enabled_services().enabled_services)
+
     unpatchable_esm_updates = 0
 
-    if (not any(i.name == "esm_infra" for i in enabled_services().enabled_services)) and (updates().summary.num_esm_infra_updates > 0):
-        unpatchable_esm_updates += updates().summary.num_esm_infra_updates
+    if ("esm-infra" not in enabled_pro_services_list) and (update_information_summary.num_esm_infra_updates > 0):
+        unpatchable_esm_updates += update_information_summary.num_esm_infra_updates
 
-    if (not any(i.name == "esm_apps" for i in enabled_services().enabled_services)) and (updates().summary.num_esm_apps_updates > 0):
-        unpatchable_esm_updates += updates().summary.num_esm_apps_updates
+    if ("esm-apps" not in enabled_pro_services_list) and (update_information_summary.num_esm_apps_updates > 0):
+        unpatchable_esm_updates += update_information_summary.num_esm_apps_updates
 
     print(unpatchable_esm_updates)
     sys.exit(os.EX_OK)
 
 except ImportError:
     # Most likely a newer version of the pro client (ubuntu-advantage-tools) is required.
-    # Return 99 so that someone takes a look.
     print("Unable to find up-to-date Pro client. Try running 'apt install ubuntu-advantage-tools' on the instance.")
     sys.exit(os.EX_UNAVAILABLE)

--- a/monitoring/security/securitystatus.py
+++ b/monitoring/security/securitystatus.py
@@ -1,22 +1,29 @@
 #!/usr/bin/env python3
 
-import json
-import subprocess
+# Prints the number of ESM updates that the instance can see, but not
+# install because it does not have the relevant ESM service enabled.
+# This helps administrators to identify and prioritise the enablement
+# of ESM across a fleet.
+import os
 import sys
 
-return_info = subprocess.check_output(["ua",  "security-status", "--format=json"])
-json_output = return_info.decode(sys.stdout.encoding)
-ua_security_status = json.loads(json_output)
+try:
+    from uaclient.api.u.pro.packages.updates.v1 import updates
+    from uaclient.api.u.pro.status.enabled_services.v1 import enabled_services
 
-if "esm-infra" not in ua_security_status["summary"]["ua"]["enabled_services"]:
-    unpatchable_esm_infra = ua_security_status["summary"]["num_esm_infra_updates"]
-else:    
-    unpatchable_esm_infra = 0
+    unpatchable_esm_updates = 0
 
-if "esm-apps" not in ua_security_status["summary"]["ua"]["enabled_services"]:
-    unpatchable_esm_apps = ua_security_status["summary"]["num_esm_apps_updates"]
-else:
-    unpatchable_esm_apps = 0    
+    if (not any(i.name == "esm_infra" for i in enabled_services().enabled_services)) and (updates().summary.num_esm_infra_updates > 0):
+        unpatchable_esm_updates += updates().summary.num_esm_infra_updates
 
-total_unpatchable_esm_updates = unpatchable_esm_infra + unpatchable_esm_apps
-print(total_unpatchable_esm_updates)
+    if (not any(i.name == "esm_apps" for i in enabled_services().enabled_services)) and (updates().summary.num_esm_apps_updates > 0):
+        unpatchable_esm_updates += updates().summary.num_esm_apps_updates
+
+    print(unpatchable_esm_updates)
+    sys.exit(os.EX_OK)
+
+except ImportError:
+    # Most likely a newer version of the pro client (ubuntu-advantage-tools) is required.
+    # Return 99 so that someone takes a look.
+    print("Unable to find up-to-date Pro client. Try running 'apt install ubuntu-advantage-tools' on the instance.")
+    sys.exit(os.EX_UNAVAILABLE)

--- a/monitoring/security/securitystatus.py
+++ b/monitoring/security/securitystatus.py
@@ -11,23 +11,22 @@ try:
     from uaclient.api.u.pro.packages.updates.v1 import updates
     from uaclient.api.u.pro.status.enabled_services.v1 import enabled_services
 
-    # Some of these calls to the pro api can take time and we have a 10 second limit on Landscape scripts
-    # so we will call the endpoints once and reuse the results
-    update_information_summary = updates().summary
-    enabled_pro_services_list = list(i.name for i in enabled_services().enabled_services)
-
-    unpatchable_esm_updates = 0
-
-    if ("esm-infra" not in enabled_pro_services_list) and (update_information_summary.num_esm_infra_updates > 0):
-        unpatchable_esm_updates += update_information_summary.num_esm_infra_updates
-
-    if ("esm-apps" not in enabled_pro_services_list) and (update_information_summary.num_esm_apps_updates > 0):
-        unpatchable_esm_updates += update_information_summary.num_esm_apps_updates
-
-    print(unpatchable_esm_updates)
-    sys.exit(os.EX_OK)
-
 except ImportError:
     # Most likely a newer version of the pro client (ubuntu-advantage-tools) is required.
     print("Unable to find up-to-date Pro client. Try running 'apt install ubuntu-advantage-tools' on the instance.")
     sys.exit(os.EX_UNAVAILABLE)
+
+# Some of these calls to the pro api can take time and we have a 10 second limit on Landscape scripts
+# so we will call the endpoints once and reuse the results
+update_information_summary = updates().summary
+enabled_pro_services_list = list(i.name for i in enabled_services().enabled_services)
+
+unpatchable_esm_updates = 0
+
+if ("esm-infra" not in enabled_pro_services_list):
+    unpatchable_esm_updates += update_information_summary.num_esm_infra_updates
+
+if ("esm-apps" not in enabled_pro_services_list):
+    unpatchable_esm_updates += update_information_summary.num_esm_apps_updates
+
+print(unpatchable_esm_updates)


### PR DESCRIPTION
Move from using the JSON output of the UA client to the new Pro client API, which is expected to stay stable for longer:
https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/references/api.html

I also added a helpful error message to alert people that the Ubuntu Pro client was not working correctly and probably needed to be installed or updated.

Run some basic tests:
- 16.04 and 18.04 initially give an error with helpful text advising that ubuntu-advantage-tools needs updating, as the version included in these old releases does not support the Ubuntu Pro API.
- 16.04 and 18.04 without Ubuntu Pro show unpatchable updates, as expected (as these releases are in ESM only for all updates)
- 16.04 Pro and 18.04 Pro show no unpatchable updates, as Ubuntu Pro has esm-infra, which will let these updates be patched
- 20.04 and 22.04 without Ubuntu Pro had no unpatchable updates by default, as these are still in standard security maintenance. I installed pdfresurrect, which is a universe package with an ESM update in esm-apps. 20.04 and 22.04 then showed 1 unpatachable update, as expected, and 16.04 and 18.04 showed an additional unpatchable update. Applying Ubuntu Pro to these instances resolved these to 0.