### PR TITLE
Fix script name in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,4 +181,4 @@ _Note: some scripts may require python3-requests deb (or PyPI requests) in order
 ### Debugging
 
 - **Tutorial**: Collect a large amount of SnapD and core system information that could be useful when debugging a system with Canonical Support
-    - [**remove-user.py**](./debugging/snap-debug-info.sh)
+    - [**snap-debug-info.py**](./debugging/snap-debug-info.sh)


### PR DESCRIPTION
Fix script name for snap-debug-info